### PR TITLE
Edit quiz review

### DIFF
--- a/assessly/src/config/api.ts
+++ b/assessly/src/config/api.ts
@@ -106,6 +106,16 @@ saveQuizToCanvas: async (quizId: string) => {
     return response.json();
   },
 
+syncFromCanvas: async (quizId: string) => {
+    const headers = await getAuthHeaders();
+    const response = await fetch(`${API_BASE}/api/quizzes/${quizId}/sync-from-canvas`, { method: 'POST', headers });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.detail || 'Failed to sync from Canvas');
+    }
+    return response.json();
+  },
+
 saveQuizEdits: async (quizId: string, questions: { internal_question_id: string; points_possible: number }[]) => {
     const headers = await getAuthHeaders();
     const response = await fetch(`${API_BASE}/api/quizzes/${quizId}/edits`, {

--- a/assessly/src/config/api.ts
+++ b/assessly/src/config/api.ts
@@ -106,6 +106,16 @@ saveQuizToCanvas: async (quizId: string) => {
     return response.json();
   },
 
+unpublishQuiz: async (quizId: string) => {
+    const headers = await getAuthHeaders();
+    const response = await fetch(`${API_BASE}/api/quizzes/${quizId}/unpublish`, { method: 'POST', headers });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.detail || 'Failed to unpublish quiz');
+    }
+    return response.json();
+  },
+
 revertToDraft: async (quizId: string) => {
     const headers = await getAuthHeaders();
     const response = await fetch(`${API_BASE}/api/quizzes/${quizId}/revert-to-draft`, { method: 'POST', headers });

--- a/assessly/src/config/api.ts
+++ b/assessly/src/config/api.ts
@@ -106,6 +106,16 @@ saveQuizToCanvas: async (quizId: string) => {
     return response.json();
   },
 
+deleteQuiz: async (quizId: string) => {
+    const headers = await getAuthHeaders();
+    const response = await fetch(`${API_BASE}/api/quizzes/${quizId}`, { method: 'DELETE', headers });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.detail || 'Failed to delete quiz');
+    }
+    return response.json();
+  },
+
 generateQuiz: async (files: { url: string; display_name: string; content_type: string }[], course_id?: number, quiz_ids?: number[], question_count?: number, title?: string) => {
     const headers = await getAuthHeaders();
     const response = await fetch(`${API_BASE}/api/generate-quiz`, {

--- a/assessly/src/config/api.ts
+++ b/assessly/src/config/api.ts
@@ -106,6 +106,16 @@ saveQuizToCanvas: async (quizId: string) => {
     return response.json();
   },
 
+revertToDraft: async (quizId: string) => {
+    const headers = await getAuthHeaders();
+    const response = await fetch(`${API_BASE}/api/quizzes/${quizId}/revert-to-draft`, { method: 'POST', headers });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.detail || 'Failed to revert quiz to draft');
+    }
+    return response.json();
+  },
+
 deleteQuiz: async (quizId: string) => {
     const headers = await getAuthHeaders();
     const response = await fetch(`${API_BASE}/api/quizzes/${quizId}`, { method: 'DELETE', headers });

--- a/assessly/src/config/api.ts
+++ b/assessly/src/config/api.ts
@@ -106,6 +106,20 @@ saveQuizToCanvas: async (quizId: string) => {
     return response.json();
   },
 
+saveQuizEdits: async (quizId: string, questions: { internal_question_id: string; points_possible: number }[]) => {
+    const headers = await getAuthHeaders();
+    const response = await fetch(`${API_BASE}/api/quizzes/${quizId}/edits`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ questions }),
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.detail || 'Failed to save quiz edits');
+    }
+    return response.json();
+  },
+
 unpublishQuiz: async (quizId: string) => {
     const headers = await getAuthHeaders();
     const response = await fetch(`${API_BASE}/api/quizzes/${quizId}/unpublish`, { method: 'POST', headers });

--- a/assessly/src/pages/dashboard.tsx
+++ b/assessly/src/pages/dashboard.tsx
@@ -1,6 +1,7 @@
 import { useUser, useClerk } from '@clerk/clerk-react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/dashboard.css';
+import '../styles/quizStructure.css';
 import ufImg from '../assets/ufimg.png';
 import cardImg from '../assets/cardimg.jpg';
 import { useEffect, useState } from 'react';
@@ -15,6 +16,7 @@ function Dashboard() {
   const [coursesWithQuizzes, setCoursesWithQuizzes] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedCourse, setSelectedCourse] = useState<any>(null);
+  const [isCourseLoading, setIsCourseLoading] = useState(false);
   const [syncWarning, setSyncWarning] = useState(false);
   // TODO: retrieve recently drafted quizzes 
   //const [cachedQuizzes, setCachedQuizzes] = useState<any[]>([]);
@@ -58,6 +60,7 @@ function Dashboard() {
 
   async function handleCourseClick(course: any) {
     setSyncWarning(false);
+    setIsCourseLoading(true);
     try {
       const quizzesData = await api.getAssesslyQuizzes(course.id);
       if (quizzesData.sync_warning) setSyncWarning(true);
@@ -69,6 +72,8 @@ function Dashboard() {
     } catch (error) {
       console.error(`Error fetching quizzes for ${course.name}:`, error);
       setSelectedCourse({ ...course, quiz_count: 0, quizzes: [] });
+    } finally {
+      setIsCourseLoading(false);
     }
   }
   
@@ -99,7 +104,12 @@ function Dashboard() {
       <hr className="separator" />
 
       <main className="main">
-        {selectedCourse ? (
+        {isCourseLoading ? (
+          <div className="quiz-review-loading-screen">
+            <div className="loader" />
+            <p className="quiz-review-loading-text">Retrieving Course Practice Material</p>
+          </div>
+        ) : selectedCourse ? (
           <section className="section">
             <div className="quiz-header">
               <div className="sub-nav">

--- a/assessly/src/pages/quizReview.tsx
+++ b/assessly/src/pages/quizReview.tsx
@@ -55,28 +55,23 @@ function QuizReview() {
 
   async function handleSave() {
     if (!quizId) return;
+    // Only send questions that actually have changes in pointsEdits
+    if (Object.keys(pointsEdits).length === 0) return;
     setIsSaving(true);
     setSaveError(null);
     try {
-      // Build the full list of questions with any edited points merged in
-      // Coerce to number — empty string edits fall back to 1
-      const resolvedPoints = (id: string, fallback: number): number => {
-        const edit = pointsEdits[id];
-        if (edit === '' || edit === undefined) return fallback;
-        const n = Number(edit);
-        return isNaN(n) || n < 1 ? 1 : n;
-      };
-      const questionUpdates = questions.map((q) => ({
-        internal_question_id: q.internal_question_id,
-        points_possible: resolvedPoints(q.internal_question_id, q.points_possible),
+      const questionUpdates = Object.entries(pointsEdits).map(([id, val]) => ({
+        internal_question_id: id,
+        points_possible: Number(val),
       }));
       await api.saveQuizEdits(quizId, questionUpdates);
-      // Commit edits into questions state so UI reflects saved values
+      // Commit only the changed questions into state
       setQuestions((prev) =>
-        prev.map((q) => ({
-          ...q,
-          points_possible: resolvedPoints(q.internal_question_id, q.points_possible),
-        }))
+        prev.map((q) =>
+          q.internal_question_id in pointsEdits
+            ? { ...q, points_possible: Number(pointsEdits[q.internal_question_id]) }
+            : q
+        )
       );
       setPointsEdits({});
     } catch (e: any) {
@@ -148,9 +143,19 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
                               setPointsEdits((prev) => ({ ...prev, [activeQuestion.internal_question_id]: e.target.value }));
                             }}
                             onBlur={(e) => {
-                              const val = parseFloat(e.target.value);
-                              // Revert to 1 if left empty or invalid
-                              setPointsEdits((prev) => ({ ...prev, [activeQuestion.internal_question_id]: isNaN(val) || val < 1 ? 1 : val }));
+                              const id = activeQuestion.internal_question_id;
+                              const raw = parseFloat(e.target.value);
+                              const resolved = isNaN(raw) || raw < 1 ? 1 : raw;
+                              setPointsEdits((prev) => {
+                                const next = { ...prev };
+                                // If resolved value matches the original, remove from edits (no change)
+                                if (resolved === activeQuestion.points_possible) {
+                                  delete next[id];
+                                } else {
+                                  next[id] = resolved;
+                                }
+                                return next;
+                              });
                             }}
                           />
                           <span className="quiz-review-points-label">pts</span>

--- a/assessly/src/pages/quizReview.tsx
+++ b/assessly/src/pages/quizReview.tsx
@@ -21,7 +21,7 @@ function QuizReview() {
   const [activeQuestionIndex, setActiveQuestionIndex] = useState(0);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isFinishModalOpen, setIsFinishModalOpen] = useState(false);
-  const [activeAction, setActiveAction] = useState<'delete' | 'revert' | 'save' | 'publish' | null>(null);
+  const [activeAction, setActiveAction] = useState<'delete' | 'revert' | 'save' | 'publish' | 'unpublish' | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -207,8 +207,32 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
                 {activeAction === 'delete' ? 'Deleting...' : 'Delete Quiz'}
               </button>
 
-              {/* saved_to_canvas: revert to draft (removes from Canvas, keeps in MongoDB) */}
-              {quizStatus === 'saved_to_canvas' && (
+              {/* published_on_canvas: unpublish (keeps on Canvas as draft) */}
+              {quizStatus === 'published_on_canvas' && (
+                <button
+                  type="button"
+                  className="quiz-review-delete-cancel"
+                  disabled={!!activeAction}
+                  onClick={async () => {
+                    if (!quizId) return;
+                    setActiveAction('unpublish');
+                    setActionError(null);
+                    try {
+                      await api.unpublishQuiz(quizId);
+                      setIsFinishModalOpen(false);
+                      navigate('/dashboard');
+                    } catch (e: any) {
+                      setActionError(e.message || 'Failed to unpublish quiz.');
+                      setActiveAction(null);
+                    }
+                  }}
+                >
+                  {activeAction === 'unpublish' ? 'Unpublishing...' : 'Unpublish from Canvas'}
+                </button>
+              )}
+
+              {/* saved_to_canvas or published_on_canvas: revert to draft (removes from Canvas, keeps in MongoDB) */}
+              {(quizStatus === 'saved_to_canvas' || quizStatus === 'published_on_canvas') && (
                 <button
                   type="button"
                   className="quiz-review-delete-cancel"

--- a/assessly/src/pages/quizReview.tsx
+++ b/assessly/src/pages/quizReview.tsx
@@ -30,6 +30,9 @@ function QuizReview() {
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
+  // Set of internal_question_ids that were updated during the Canvas sync
+  const [changedQuestionIds, setChangedQuestionIds] = useState<Set<string>>(new Set());
+
   useEffect(() => {
     if (!quizId) {
       setError('No quiz ID provided.');
@@ -39,9 +42,20 @@ function QuizReview() {
     async function loadQuiz() {
       try {
         const doc = await api.getQuiz(quizId!);
-        setQuizTitle(doc.title || 'Quiz Review');
-        setQuestions(doc.questions || []);
-        setQuizStatus(doc.status || '');
+        const status = doc.status || '';
+
+        // If the quiz is on Canvas, sync first so we never show stale data
+        if (status === 'saved_to_canvas' || status === 'published_on_canvas') {
+          const syncResult = await api.syncFromCanvas(quizId!);
+          setQuizTitle(syncResult.quiz.title || 'Quiz Review');
+          setQuestions(syncResult.quiz.questions || []);
+          setQuizStatus(status);
+          setChangedQuestionIds(new Set(syncResult.changed_question_ids));
+        } else {
+          setQuizTitle(doc.title || 'Quiz Review');
+          setQuestions(doc.questions || []);
+          setQuizStatus(status);
+        }
       } catch (e: any) {
         setError(e.message || 'Failed to load quiz.');
       } finally {
@@ -99,7 +113,19 @@ function QuizReview() {
     }
   }
 
-if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading quiz...</p></div>;
+if (loading) return (
+    <div className="page">
+      <div className="top-bar">
+        <h2 className="top-bar-text">ASSESSLY</h2>
+        <img src={questionMark} alt="Help button" className="top-bar-help" />
+      </div>
+      <hr />
+      <div className="quiz-review-loading-screen">
+        <div className="loader" />
+        <p className="quiz-review-loading-text">Retrieving Quiz</p>
+      </div>
+    </div>
+  );
   if (error) return <div className="page"><p style={{ padding: '2rem' }}>Error: {error}</p></div>;
 
   return (
@@ -149,6 +175,9 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
                       <div className="quiz-review-title-block">
                         <p className="quiz-review-group">{quizTitle}</p>
                         <p className="quiz-review-question-label">Question {activeQuestionIndex + 1}</p>
+                        {changedQuestionIds.has(activeQuestion.internal_question_id) && (
+                          <span className="quiz-review-new-changes-badge">New Changes</span>
+                        )}
                         <div className="quiz-review-points-row">
                           <input
                             type="number"

--- a/assessly/src/pages/quizReview.tsx
+++ b/assessly/src/pages/quizReview.tsx
@@ -53,6 +53,24 @@ function QuizReview() {
 
   const activeQuestion = questions[activeQuestionIndex];
 
+  // Flushes any pending pointsEdits to the backend. Called implicitly before Canvas actions.
+  async function flushEdits() {
+    if (!quizId || Object.keys(pointsEdits).length === 0) return;
+    const questionUpdates = Object.entries(pointsEdits).map(([id, val]) => ({
+      internal_question_id: id,
+      points_possible: Number(val),
+    }));
+    await api.saveQuizEdits(quizId, questionUpdates);
+    setQuestions((prev) =>
+      prev.map((q) =>
+        q.internal_question_id in pointsEdits
+          ? { ...q, points_possible: Number(pointsEdits[q.internal_question_id]) }
+          : q
+      )
+    );
+    setPointsEdits({});
+  }
+
   async function handleSave() {
     if (!quizId) return;
     // Only send questions that actually have changes in pointsEdits
@@ -342,6 +360,7 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
                     setActiveAction('save');
                     setActionError(null);
                     try {
+                      await flushEdits();
                       await api.saveQuizToCanvas(quizId);
                       setIsFinishModalOpen(false);
                       navigate('/dashboard');
@@ -366,6 +385,7 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
                     setActiveAction('publish');
                     setActionError(null);
                     try {
+                      await flushEdits();
                       await api.publishQuiz(quizId);
                       setIsFinishModalOpen(false);
                       navigate('/dashboard');

--- a/assessly/src/pages/quizReview.tsx
+++ b/assessly/src/pages/quizReview.tsx
@@ -20,7 +20,7 @@ function QuizReview() {
   const [activeQuestionIndex, setActiveQuestionIndex] = useState(0);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isFinishModalOpen, setIsFinishModalOpen] = useState(false);
-  const [isActionLoading, setIsActionLoading] = useState(false);
+  const [activeAction, setActiveAction] = useState<'delete' | 'save' | 'publish' | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -177,7 +177,7 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
 
       {/* Finish modal */}
       {isFinishModalOpen && (
-        <div className="quiz-review-modal-overlay" role="presentation" onClick={() => { if (!isActionLoading) setIsFinishModalOpen(false); }}>
+        <div className="quiz-review-modal-overlay" role="presentation" onClick={() => { if (!activeAction) setIsFinishModalOpen(false); }}>
           <div className="quiz-review-delete-modal" role="dialog" aria-modal="true" onClick={(e) => e.stopPropagation()}>
             <h2 className="quiz-review-delete-title">Finished Quiz Review</h2>
             <p className="quiz-review-delete-text">What would you like to do with this quiz?</p>
@@ -186,7 +186,7 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
               <button
                 type="button"
                 className="quiz-review-delete-cancel"
-                disabled={isActionLoading}
+                disabled={!!activeAction}
                 onClick={() => { setIsFinishModalOpen(false); navigate('/dashboard'); }}
               >
                 Keep as Draft
@@ -194,10 +194,10 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
               <button
                 type="button"
                 className="quiz-review-delete-cancel"
-                disabled={isActionLoading}
+                disabled={!!activeAction}
                 onClick={async () => {
                   if (!quizId) return;
-                  setIsActionLoading(true);
+                  setActiveAction('delete');
                   setActionError(null);
                   try {
                     await api.deleteQuiz(quizId);
@@ -205,19 +205,19 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
                     navigate('/dashboard');
                   } catch (e: any) {
                     setActionError(e.message || 'Failed to delete quiz.');
-                    setIsActionLoading(false);
+                    setActiveAction(null);
                   }
                 }}
               >
-                {isActionLoading ? 'Deleting...' : 'Delete Quiz'}
+                {activeAction === 'delete' ? 'Deleting...' : 'Delete Quiz'}
               </button>
               <button
                 type="button"
                 className="quiz-review-delete-cancel"
-                disabled={isActionLoading}
+                disabled={!!activeAction}
                 onClick={async () => {
                   if (!quizId) return;
-                  setIsActionLoading(true);
+                  setActiveAction('save');
                   setActionError(null);
                   try {
                     await api.saveQuizToCanvas(quizId);
@@ -225,19 +225,19 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
                     navigate('/dashboard');
                   } catch (e: any) {
                     setActionError(e.message || 'Failed to save quiz to Canvas.');
-                    setIsActionLoading(false);
+                    setActiveAction(null);
                   }
                 }}
               >
-                {isActionLoading ? 'Saving...' : 'Save to Canvas'}
+                {activeAction === 'save' ? 'Saving...' : 'Save to Canvas'}
               </button>
               <button
                 type="button"
                 className="quiz-review-delete-confirm"
-                disabled={isActionLoading}
+                disabled={!!activeAction}
                 onClick={async () => {
                   if (!quizId) return;
-                  setIsActionLoading(true);
+                  setActiveAction('publish');
                   setActionError(null);
                   try {
                     await api.publishQuiz(quizId);
@@ -245,11 +245,11 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
                     navigate('/dashboard');
                   } catch (e: any) {
                     setActionError(e.message || 'Failed to publish quiz.');
-                    setIsActionLoading(false);
+                    setActiveAction(null);
                   }
                 }}
               >
-                {isActionLoading ? 'Uploading...' : 'Publish to Canvas'}
+                {activeAction === 'publish' ? 'Uploading...' : 'Publish to Canvas'}
               </button>
             </div>
           </div>

--- a/assessly/src/pages/quizReview.tsx
+++ b/assessly/src/pages/quizReview.tsx
@@ -200,6 +200,26 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
                   setIsActionLoading(true);
                   setActionError(null);
                   try {
+                    await api.deleteQuiz(quizId);
+                    setIsFinishModalOpen(false);
+                    navigate('/dashboard');
+                  } catch (e: any) {
+                    setActionError(e.message || 'Failed to delete quiz.');
+                    setIsActionLoading(false);
+                  }
+                }}
+              >
+                {isActionLoading ? 'Deleting...' : 'Delete Quiz'}
+              </button>
+              <button
+                type="button"
+                className="quiz-review-delete-cancel"
+                disabled={isActionLoading}
+                onClick={async () => {
+                  if (!quizId) return;
+                  setIsActionLoading(true);
+                  setActionError(null);
+                  try {
                     await api.saveQuizToCanvas(quizId);
                     setIsFinishModalOpen(false);
                     navigate('/dashboard');

--- a/assessly/src/pages/quizReview.tsx
+++ b/assessly/src/pages/quizReview.tsx
@@ -6,6 +6,15 @@ import backArrow from '../assets/Caret_Left.png';
 import { api } from '../config/api';
 
 import '../styles/quizStructure.css';
+import '../styles/quizReview.css';
+
+/** Strip HTML tags, returning plain text for display in inputs/textareas. */
+function stripHtml(html: string): string {
+  if (!html) return '';
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.textContent || div.innerText || '';
+}
 
 function QuizReview() {
   const navigate = useNavigate();
@@ -24,13 +33,10 @@ function QuizReview() {
   const [activeAction, setActiveAction] = useState<'delete' | 'revert' | 'save' | 'publish' | 'unpublish' | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  // Tracks edited points per question: { [internal_question_id]: points }
-  // Allows empty string mid-edit so the user can fully backspace before typing a new value
   const [pointsEdits, setPointsEdits] = useState<Record<string, number | string>>({});
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
-  // Set of internal_question_ids that were updated during the Canvas sync
   const [changedQuestionIds, setChangedQuestionIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
@@ -44,7 +50,6 @@ function QuizReview() {
         const doc = await api.getQuiz(quizId!);
         const status = doc.status || '';
 
-        // If the quiz is on Canvas, sync first so we never show stale data
         if (status === 'saved_to_canvas' || status === 'published_on_canvas') {
           const syncResult = await api.syncFromCanvas(quizId!);
           setQuizTitle(syncResult.quiz.title || 'Quiz Review');
@@ -67,7 +72,6 @@ function QuizReview() {
 
   const activeQuestion = questions[activeQuestionIndex];
 
-  // Flushes any pending pointsEdits to the backend. Called implicitly before Canvas actions.
   async function flushEdits() {
     if (!quizId || Object.keys(pointsEdits).length === 0) return;
     const questionUpdates = Object.entries(pointsEdits).map(([id, val]) => ({
@@ -87,7 +91,6 @@ function QuizReview() {
 
   async function handleSave() {
     if (!quizId) return;
-    // Only send questions that actually have changes in pointsEdits
     if (Object.keys(pointsEdits).length === 0) return;
     setIsSaving(true);
     setSaveError(null);
@@ -97,7 +100,6 @@ function QuizReview() {
         points_possible: Number(val),
       }));
       await api.saveQuizEdits(quizId, questionUpdates);
-      // Commit only the changed questions into state
       setQuestions((prev) =>
         prev.map((q) =>
           q.internal_question_id in pointsEdits
@@ -113,7 +115,7 @@ function QuizReview() {
     }
   }
 
-if (loading) return (
+  if (loading) return (
     <div className="page">
       <div className="top-bar">
         <h2 className="top-bar-text">ASSESSLY</h2>
@@ -126,164 +128,211 @@ if (loading) return (
       </div>
     </div>
   );
+
   if (error) return <div className="page"><p style={{ padding: '2rem' }}>Error: {error}</p></div>;
 
   return (
-    <div className="page">
+    <div className="page qr-page">
+      {/* Top bar */}
       <div className="top-bar">
         <h2 className="top-bar-text" onClick={() => navigate('/dashboard')}>ASSESSLY</h2>
         <img src={questionMark} alt="Help button" className="top-bar-help" />
       </div>
       <hr />
 
-      <div className="content">
-        <div className="left">
-          <img
-            src={backArrow}
-            className="back-arrow"
-            alt="Back button"
-            onClick={() => navigate(-1)}
-            style={{ cursor: 'pointer' }}
-          />
-        </div>
+      {/* Two-column layout */}
+      <div className="qr-layout">
 
-        <div className="questions-container">
-          <div className="questions" style={{ padding: 0, overflow: 'hidden' }}>
-            <div style={{ display: 'flex', width: '100%', height: '100%', minHeight: 0 }}>
+        {/* ── Left sidebar ── */}
+        <aside className="qr-sidebar">
+          <div className="qr-sidebar-header">
+            <button
+              type="button"
+              className="qr-back-btn"
+              onClick={() => navigate(-1)}
+              aria-label="Go back"
+            >
+              <img src={backArrow} className="back-arrow" alt="" />
+              <span>Back</span>
+            </button>
+            <p className="qr-sidebar-quiz-title">{quizTitle}</p>
+            <p className="qr-sidebar-count">Questions &nbsp;<span>{questions.length}</span></p>
+          </div>
 
-              {/* Question number sidebar */}
-              <div className="quiz-review-progress">
-                {questions.map((_, index) => (
-                  <button
-                    key={index}
-                    type="button"
-                    className={`quiz-review-progress-item ${index === activeQuestionIndex ? 'active' : ''}`}
-                    onClick={() => setActiveQuestionIndex(index)}
-                    aria-label={`Go to question ${index + 1}`}
-                  >
-                    {index + 1}
-                  </button>
-                ))}
-              </div>
+          <div className="qr-sidebar-list">
+            {questions.map((q, index) => (
+              <button
+                key={q.internal_question_id || index}
+                type="button"
+                className={`qr-sidebar-item${index === activeQuestionIndex ? ' active' : ''}`}
+                onClick={() => setActiveQuestionIndex(index)}
+              >
+                <span className="qr-sidebar-num">{index + 1}</span>
+                <span className="qr-sidebar-preview">
+                  {stripHtml(q.question_stem_html).slice(0, 60) || 'Question'}
+                </span>
+              </button>
+            ))}
+          </div>
 
-              {/* Main panel */}
-              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: '1.9rem 2.1rem 1.35rem', minHeight: 0 }}>
-                {activeQuestion ? (
-                  <>
-                    {/* Header */}
-                    <div className="quiz-review-header">
-                      <div className="quiz-review-title-block">
-                        <p className="quiz-review-group">{quizTitle}</p>
-                        <p className="quiz-review-question-label">Question {activeQuestionIndex + 1}</p>
-                        {changedQuestionIds.has(activeQuestion.internal_question_id) && (
-                          <span className="quiz-review-new-changes-badge">New Changes</span>
-                        )}
-                        <div className="quiz-review-points-row">
-                          <input
-                            type="number"
-                            min={1}
-                            step={1}
-                            className="quiz-review-points-input"
-                            value={pointsEdits[activeQuestion.internal_question_id] ?? activeQuestion.points_possible}
-                            onChange={(e) => {
-                              // Allow empty string so the user can fully backspace before typing
-                              setPointsEdits((prev) => ({ ...prev, [activeQuestion.internal_question_id]: e.target.value }));
-                            }}
-                            onBlur={(e) => {
-                              const id = activeQuestion.internal_question_id;
-                              const raw = parseFloat(e.target.value);
-                              const resolved = isNaN(raw) || raw < 1 ? 1 : raw;
-                              setPointsEdits((prev) => {
-                                const next = { ...prev };
-                                // If resolved value matches the original, remove from edits (no change)
-                                if (resolved === activeQuestion.points_possible) {
-                                  delete next[id];
-                                } else {
-                                  next[id] = resolved;
-                                }
-                                return next;
-                              });
-                            }}
-                          />
-                          <span className="quiz-review-points-label">pts</span>
-                        </div>
-                        {saveError && <p style={{ color: 'red', fontSize: '0.8rem', margin: '0.25rem 0 0' }}>{saveError}</p>}
-                      </div>
-                      <div className="quiz-review-side-actions">
-                        <button
-                          type="button"
-                          className="quiz-review-icon-button"
-                          aria-label="Save changes"
-                          disabled={isSaving}
-                          onClick={handleSave}
-                        >
-                          {isSaving
-                            ? <span className="quiz-review-save-spinner" aria-hidden="true" />
-                            : <span className="quiz-review-save-icon" aria-hidden="true" />
+          <div className="qr-sidebar-footer">
+            <button
+              type="button"
+              className="qr-finish-btn"
+              onClick={() => setIsFinishModalOpen(true)}
+            >
+              Finish review
+            </button>
+          </div>
+        </aside>
+
+        {/* ── Main panel ── */}
+        <main className="qr-main">
+          {activeQuestion ? (
+            <div className="qr-card">
+
+              {/* Card top row */}
+              <div className="qr-card-topbar">
+                <div className="qr-card-topleft">
+                  <div className="qr-question-label-row">
+                    <span className="qr-question-label">Question {activeQuestionIndex + 1}</span>
+                    {changedQuestionIds.has(activeQuestion.internal_question_id) && (
+                      <span className="quiz-review-new-changes-badge">New Changes</span>
+                    )}
+                  </div>
+                  <div className="qr-points-row">
+                    <input
+                      type="number"
+                      min={1}
+                      step={1}
+                      className="quiz-review-points-input"
+                      value={pointsEdits[activeQuestion.internal_question_id] ?? activeQuestion.points_possible}
+                      onChange={(e) => {
+                        setPointsEdits((prev) => ({ ...prev, [activeQuestion.internal_question_id]: e.target.value }));
+                      }}
+                      onBlur={(e) => {
+                        const id = activeQuestion.internal_question_id;
+                        const raw = parseFloat(e.target.value);
+                        const resolved = isNaN(raw) || raw < 1 ? 1 : raw;
+                        setPointsEdits((prev) => {
+                          const next = { ...prev };
+                          if (resolved === activeQuestion.points_possible) {
+                            delete next[id];
+                          } else {
+                            next[id] = resolved;
                           }
-                        </button>
-                        <button type="button" className="quiz-review-icon-button" aria-label="Add question">
-                          <span className="quiz-review-plus-icon" aria-hidden="true">+</span>
-                        </button>
-                        <button
-                          type="button"
-                          className="quiz-review-icon-button"
-                          aria-label="Delete question"
-                          onClick={() => setIsDeleteModalOpen(true)}
-                        >
-                          <span className="quiz-review-trash-icon" aria-hidden="true"></span>
-                        </button>
-                      </div>
-                    </div>
-
-                    {/* Question stem */}
-                    <h3 className="question-text" style={{ marginTop: '1.15rem', fontWeight: 400, fontSize: 'clamp(1.1rem, 1.7vw, 1.55rem)' }}
-                      dangerouslySetInnerHTML={{ __html: activeQuestion.question_stem_html }}
+                          return next;
+                        });
+                      }}
                     />
+                    <span className="quiz-review-points-label">pts</span>
+                    {saveError && <p className="qr-save-error">{saveError}</p>}
+                  </div>
+                </div>
 
-                    {/* Answer choices */}
-                    <div className="quizStepMaterialsList" style={{ marginTop: '1.5rem', display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
-                      {activeQuestion.choices?.map((choice: any) => {
-                        return (
-                          <div
-                            key={choice.internal_choice_id}
-                            className="quizInputText"
-                            style={{
-                              textAlign: 'left',
-                              background: choice.is_correct ? 'rgba(70, 130, 120, 0.15)' : '#ffffff',
-                              color: '#1f2f2c',
-                              border: choice.is_correct ? '1px solid rgba(70, 130, 120, 0.4)' : '1px solid #C0C0C0',
-                              fontFamily: '"Red Hat Display", sans-serif',
-                              fontSize: '1rem',
-                            }}
-                            dangerouslySetInnerHTML={{ __html: choice.text_html }}
-                          />
-                        );
-                      })}
-                    </div>
-                  </>
-                ) : (
-                  <p>No questions available.</p>
-                )}
-
-                {/* Navigation buttons */}
-                <div className="buttons" style={{ marginTop: 'auto' }}>
-                  {activeQuestionIndex > 0 ? (
-                    <button className="button-back" onClick={() => setActiveQuestionIndex((i) => i - 1)}>Back</button>
-                  ) : (
-                    <span />
-                  )}
-                  {activeQuestionIndex < questions.length - 1 ? (
-                    <button className="button-next" onClick={() => setActiveQuestionIndex((i) => i + 1)}>Next</button>
-                  ) : (
-                    <button className="button-next" onClick={() => setIsFinishModalOpen(true)}>Finish</button>
-                  )}
+                <div className="qr-card-topright">
+                  <div className="qr-card-topright-actions">
+                    <button
+                      type="button"
+                      className="qr-save-text-btn"
+                      aria-label="Save changes"
+                      disabled={isSaving}
+                      onClick={handleSave}
+                    >
+                      {isSaving ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      type="button"
+                      className="qr-trash-btn"
+                      aria-label="Delete question"
+                      onClick={() => setIsDeleteModalOpen(true)}
+                    >
+                      <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#d93025" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="3 6 5 6 21 6" />
+                        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                        <path d="M10 11v6" />
+                        <path d="M14 11v6" />
+                        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                      </svg>
+                    </button>
+                  </div>
+                  <span className="qr-question-type">Multiple Choice</span>
                 </div>
               </div>
 
+              {/* Divider */}
+              <div className="qr-card-divider" />
+
+              {/* Question stem */}
+              <textarea
+                className="qr-question-textarea"
+                value={stripHtml(activeQuestion.question_stem_html)}
+                readOnly
+                rows={2}
+              />
+
+              {/* Answer choices */}
+              <div className="qr-choices">
+                {activeQuestion.choices?.map((choice: any) => (
+                  <div key={choice.internal_choice_id} className={`qr-choice-row${choice.is_correct ? ' correct' : ''}`}>
+                    <span className={`qr-radio-circle${choice.is_correct ? ' correct' : ''}`}>
+                      {choice.is_correct && (
+                        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                          <path d="M2 6l3 3 5-5" stroke="#ffffff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                        </svg>
+                      )}
+                    </span>
+                    <input
+                      type="text"
+                      className={`qr-choice-input${choice.is_correct ? ' correct' : ''}`}
+                      value={stripHtml(choice.text_html)}
+                      readOnly
+                    />
+                    <button
+                      type="button"
+                      className="qr-choice-trash-btn"
+                      aria-label="Delete choice"
+                      onClick={() => {}}
+                    >
+                      <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#d93025" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="3 6 5 6 21 6" />
+                        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                        <path d="M10 11v6" />
+                        <path d="M14 11v6" />
+                        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                      </svg>
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              {/* Add question button */}
+              <button type="button" className="qr-add-question-btn" onClick={() => {}}>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                Add question
+              </button>
+
             </div>
+          ) : (
+            <div className="qr-card" style={{ justifyContent: 'center', alignItems: 'center' }}>
+              <p style={{ color: '#666' }}>No questions available.</p>
+            </div>
+          )}
+
+          {/* Navigation — outside card, full width */}
+          <div className="qr-nav">
+            {activeQuestionIndex > 0 ? (
+              <button className="qr-nav-back" onClick={() => setActiveQuestionIndex((i) => i - 1)}>Back</button>
+            ) : (
+              <span />
+            )}
+            {activeQuestionIndex < questions.length - 1 ? (
+              <button className="qr-nav-next" onClick={() => setActiveQuestionIndex((i) => i + 1)}>Next</button>
+            ) : (
+              <button className="qr-nav-next" onClick={() => setIsFinishModalOpen(true)}>Finish</button>
+            )}
           </div>
-        </div>
+        </main>
       </div>
 
       {/* Delete modal */}
@@ -330,7 +379,7 @@ if (loading) return (
                 {activeAction === 'delete' ? 'Deleting...' : 'Delete Quiz'}
               </button>
 
-              {/* published_on_canvas: unpublish (keeps on Canvas as draft) */}
+              {/* published_on_canvas: unpublish */}
               {quizStatus === 'published_on_canvas' && (
                 <button
                   type="button"
@@ -354,7 +403,7 @@ if (loading) return (
                 </button>
               )}
 
-              {/* saved_to_canvas or published_on_canvas: revert to draft (removes from Canvas, keeps in MongoDB) */}
+              {/* saved_to_canvas or published_on_canvas: revert to draft */}
               {(quizStatus === 'saved_to_canvas' || quizStatus === 'published_on_canvas') && (
                 <button
                   type="button"

--- a/assessly/src/pages/quizReview.tsx
+++ b/assessly/src/pages/quizReview.tsx
@@ -21,7 +21,7 @@ function QuizReview() {
   const [activeQuestionIndex, setActiveQuestionIndex] = useState(0);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isFinishModalOpen, setIsFinishModalOpen] = useState(false);
-  const [activeAction, setActiveAction] = useState<'delete' | 'save' | 'publish' | null>(null);
+  const [activeAction, setActiveAction] = useState<'delete' | 'revert' | 'save' | 'publish' | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -185,16 +185,7 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
             <p className="quiz-review-delete-text">What would you like to do with this quiz?</p>
             {actionError && <p style={{ color: 'red', fontSize: '0.9rem', margin: '0.5rem 0 0' }}>{actionError}</p>}
             <div className="quiz-review-delete-actions">
-              {quizStatus !== 'generated_pending_review' && (
-                <button
-                  type="button"
-                  className="quiz-review-delete-cancel"
-                  disabled={!!activeAction}
-                  onClick={() => { setIsFinishModalOpen(false); navigate('/dashboard'); }}
-                >
-                  Keep as Draft
-                </button>
-              )}
+              {/* Delete — always shown */}
               <button
                 type="button"
                 className="quiz-review-delete-cancel"
@@ -215,46 +206,78 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
               >
                 {activeAction === 'delete' ? 'Deleting...' : 'Delete Quiz'}
               </button>
-              <button
-                type="button"
-                className="quiz-review-delete-cancel"
-                disabled={!!activeAction}
-                onClick={async () => {
-                  if (!quizId) return;
-                  setActiveAction('save');
-                  setActionError(null);
-                  try {
-                    await api.saveQuizToCanvas(quizId);
-                    setIsFinishModalOpen(false);
-                    navigate('/dashboard');
-                  } catch (e: any) {
-                    setActionError(e.message || 'Failed to save quiz to Canvas.');
-                    setActiveAction(null);
-                  }
-                }}
-              >
-                {activeAction === 'save' ? 'Saving...' : 'Save to Canvas'}
-              </button>
-              <button
-                type="button"
-                className="quiz-review-delete-confirm"
-                disabled={!!activeAction}
-                onClick={async () => {
-                  if (!quizId) return;
-                  setActiveAction('publish');
-                  setActionError(null);
-                  try {
-                    await api.publishQuiz(quizId);
-                    setIsFinishModalOpen(false);
-                    navigate('/dashboard');
-                  } catch (e: any) {
-                    setActionError(e.message || 'Failed to publish quiz.');
-                    setActiveAction(null);
-                  }
-                }}
-              >
-                {activeAction === 'publish' ? 'Uploading...' : 'Publish to Canvas'}
-              </button>
+
+              {/* saved_to_canvas: revert to draft (removes from Canvas, keeps in MongoDB) */}
+              {quizStatus === 'saved_to_canvas' && (
+                <button
+                  type="button"
+                  className="quiz-review-delete-cancel"
+                  disabled={!!activeAction}
+                  onClick={async () => {
+                    if (!quizId) return;
+                    setActiveAction('revert');
+                    setActionError(null);
+                    try {
+                      await api.revertToDraft(quizId);
+                      setIsFinishModalOpen(false);
+                      navigate('/dashboard');
+                    } catch (e: any) {
+                      setActionError(e.message || 'Failed to revert quiz to draft.');
+                      setActiveAction(null);
+                    }
+                  }}
+                >
+                  {activeAction === 'revert' ? 'Reverting...' : 'Save as Draft'}
+                </button>
+              )}
+
+              {/* generated_pending_review: save to Canvas (unpublished) */}
+              {quizStatus === 'generated_pending_review' && (
+                <button
+                  type="button"
+                  className="quiz-review-delete-cancel"
+                  disabled={!!activeAction}
+                  onClick={async () => {
+                    if (!quizId) return;
+                    setActiveAction('save');
+                    setActionError(null);
+                    try {
+                      await api.saveQuizToCanvas(quizId);
+                      setIsFinishModalOpen(false);
+                      navigate('/dashboard');
+                    } catch (e: any) {
+                      setActionError(e.message || 'Failed to save quiz to Canvas.');
+                      setActiveAction(null);
+                    }
+                  }}
+                >
+                  {activeAction === 'save' ? 'Saving...' : 'Save to Canvas'}
+                </button>
+              )}
+
+              {/* Publish — shown for draft and saved_to_canvas */}
+              {(quizStatus === 'generated_pending_review' || quizStatus === 'saved_to_canvas') && (
+                <button
+                  type="button"
+                  className="quiz-review-delete-confirm"
+                  disabled={!!activeAction}
+                  onClick={async () => {
+                    if (!quizId) return;
+                    setActiveAction('publish');
+                    setActionError(null);
+                    try {
+                      await api.publishQuiz(quizId);
+                      setIsFinishModalOpen(false);
+                      navigate('/dashboard');
+                    } catch (e: any) {
+                      setActionError(e.message || 'Failed to publish quiz.');
+                      setActiveAction(null);
+                    }
+                  }}
+                >
+                  {activeAction === 'publish' ? 'Uploading...' : 'Publish to Canvas'}
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/assessly/src/pages/quizReview.tsx
+++ b/assessly/src/pages/quizReview.tsx
@@ -24,6 +24,12 @@ function QuizReview() {
   const [activeAction, setActiveAction] = useState<'delete' | 'revert' | 'save' | 'publish' | 'unpublish' | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
+  // Tracks edited points per question: { [internal_question_id]: points }
+  // Allows empty string mid-edit so the user can fully backspace before typing a new value
+  const [pointsEdits, setPointsEdits] = useState<Record<string, number | string>>({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   useEffect(() => {
     if (!quizId) {
       setError('No quiz ID provided.');
@@ -46,6 +52,39 @@ function QuizReview() {
   }, [quizId]);
 
   const activeQuestion = questions[activeQuestionIndex];
+
+  async function handleSave() {
+    if (!quizId) return;
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      // Build the full list of questions with any edited points merged in
+      // Coerce to number — empty string edits fall back to 1
+      const resolvedPoints = (id: string, fallback: number): number => {
+        const edit = pointsEdits[id];
+        if (edit === '' || edit === undefined) return fallback;
+        const n = Number(edit);
+        return isNaN(n) || n < 1 ? 1 : n;
+      };
+      const questionUpdates = questions.map((q) => ({
+        internal_question_id: q.internal_question_id,
+        points_possible: resolvedPoints(q.internal_question_id, q.points_possible),
+      }));
+      await api.saveQuizEdits(quizId, questionUpdates);
+      // Commit edits into questions state so UI reflects saved values
+      setQuestions((prev) =>
+        prev.map((q) => ({
+          ...q,
+          points_possible: resolvedPoints(q.internal_question_id, q.points_possible),
+        }))
+      );
+      setPointsEdits({});
+    } catch (e: any) {
+      setSaveError(e.message || 'Failed to save.');
+    } finally {
+      setIsSaving(false);
+    }
+  }
 
 if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading quiz...</p></div>;
   if (error) return <div className="page"><p style={{ padding: '2rem' }}>Error: {error}</p></div>;
@@ -97,8 +136,40 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
                       <div className="quiz-review-title-block">
                         <p className="quiz-review-group">{quizTitle}</p>
                         <p className="quiz-review-question-label">Question {activeQuestionIndex + 1}</p>
+                        <div className="quiz-review-points-row">
+                          <input
+                            type="number"
+                            min={1}
+                            step={1}
+                            className="quiz-review-points-input"
+                            value={pointsEdits[activeQuestion.internal_question_id] ?? activeQuestion.points_possible}
+                            onChange={(e) => {
+                              // Allow empty string so the user can fully backspace before typing
+                              setPointsEdits((prev) => ({ ...prev, [activeQuestion.internal_question_id]: e.target.value }));
+                            }}
+                            onBlur={(e) => {
+                              const val = parseFloat(e.target.value);
+                              // Revert to 1 if left empty or invalid
+                              setPointsEdits((prev) => ({ ...prev, [activeQuestion.internal_question_id]: isNaN(val) || val < 1 ? 1 : val }));
+                            }}
+                          />
+                          <span className="quiz-review-points-label">pts</span>
+                        </div>
+                        {saveError && <p style={{ color: 'red', fontSize: '0.8rem', margin: '0.25rem 0 0' }}>{saveError}</p>}
                       </div>
                       <div className="quiz-review-side-actions">
+                        <button
+                          type="button"
+                          className="quiz-review-icon-button"
+                          aria-label="Save changes"
+                          disabled={isSaving}
+                          onClick={handleSave}
+                        >
+                          {isSaving
+                            ? <span className="quiz-review-save-spinner" aria-hidden="true" />
+                            : <span className="quiz-review-save-icon" aria-hidden="true" />
+                          }
+                        </button>
                         <button type="button" className="quiz-review-icon-button" aria-label="Add question">
                           <span className="quiz-review-plus-icon" aria-hidden="true">+</span>
                         </button>

--- a/assessly/src/pages/quizReview.tsx
+++ b/assessly/src/pages/quizReview.tsx
@@ -14,6 +14,7 @@ function QuizReview() {
 
   const [questions, setQuestions] = useState<any[]>([]);
   const [quizTitle, setQuizTitle] = useState('');
+  const [quizStatus, setQuizStatus] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -34,6 +35,7 @@ function QuizReview() {
         const doc = await api.getQuiz(quizId!);
         setQuizTitle(doc.title || 'Quiz Review');
         setQuestions(doc.questions || []);
+        setQuizStatus(doc.status || '');
       } catch (e: any) {
         setError(e.message || 'Failed to load quiz.');
       } finally {
@@ -183,14 +185,16 @@ if (loading) return <div className="page"><p style={{ padding: '2rem' }}>Loading
             <p className="quiz-review-delete-text">What would you like to do with this quiz?</p>
             {actionError && <p style={{ color: 'red', fontSize: '0.9rem', margin: '0.5rem 0 0' }}>{actionError}</p>}
             <div className="quiz-review-delete-actions">
-              <button
-                type="button"
-                className="quiz-review-delete-cancel"
-                disabled={!!activeAction}
-                onClick={() => { setIsFinishModalOpen(false); navigate('/dashboard'); }}
-              >
-                Keep as Draft
-              </button>
+              {quizStatus !== 'generated_pending_review' && (
+                <button
+                  type="button"
+                  className="quiz-review-delete-cancel"
+                  disabled={!!activeAction}
+                  onClick={() => { setIsFinishModalOpen(false); navigate('/dashboard'); }}
+                >
+                  Keep as Draft
+                </button>
+              )}
               <button
                 type="button"
                 className="quiz-review-delete-cancel"

--- a/assessly/src/pages/quizStructure.tsx
+++ b/assessly/src/pages/quizStructure.tsx
@@ -1,6 +1,5 @@
 import questionMark from '../assets/Question_Mark.png';
 import backArrow from '../assets/Caret_Left.png';
-import star from '../assets/star.png';
 
 import '../styles/quizStructure.css';
 
@@ -612,15 +611,8 @@ function QuizStructure() {
         {isGenerating && (
             <div className="quiz-generating-overlay" role="status" aria-live="polite" aria-label="Quiz is generating">
                 <div className="quiz-generating-stack">
-                    <div className="quiz-generating-row">
-                        <div aria-hidden="true">
-                            <img src={star}></img>
-                        </div>
-                        <p className="quiz-generating-text">
-                            <span>Quiz</span>
-                            <span>Generating</span>
-                        </p>
-                    </div>
+                    <div className="cube-loader" aria-hidden="true" />
+                    <p className="quiz-generating-label">Crafting your quiz</p>
                 </div>
             </div>
         )}

--- a/assessly/src/styles/quizReview.css
+++ b/assessly/src/styles/quizReview.css
@@ -1,0 +1,495 @@
+/* ─── Quiz Review Page Layout ─── */
+
+.qr-page {
+  overflow: hidden;
+}
+
+.qr-layout {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  gap: 1.25rem;
+  margin-top: 1.25rem;
+}
+
+/* ─── Sidebar ─── */
+
+.qr-sidebar {
+  display: flex;
+  flex-direction: column;
+  width: 260px;
+  flex-shrink: 0;
+  background: #f5f5f3;
+  border: 1px solid #e0e0dd;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.qr-sidebar-header {
+  padding: 1rem 1.1rem 0.85rem;
+  border-bottom: 1px solid #e0e0dd;
+}
+
+.qr-back-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0;
+  margin-bottom: 0.75rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #444;
+}
+
+.qr-back-btn:hover {
+  color: #111;
+}
+
+.qr-back-btn .back-arrow {
+  width: 0.7rem;
+  height: auto;
+  padding: 4px;
+  border-radius: 50%;
+  background: #333;
+}
+
+.qr-sidebar-quiz-title {
+  margin: 0 0 0.25rem;
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: #111;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.qr-sidebar-count {
+  margin: 0;
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 0.8rem;
+  color: #666;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.qr-sidebar-count span {
+  font-weight: 700;
+  color: #111;
+}
+
+.qr-sidebar-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  scrollbar-width: thin;
+  scrollbar-color: #ccc #f5f5f3;
+}
+
+.qr-sidebar-list::-webkit-scrollbar {
+  width: 5px;
+}
+
+.qr-sidebar-list::-webkit-scrollbar-thumb {
+  background: #ccc;
+  border-radius: 999px;
+}
+
+.qr-sidebar-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1.5px solid #e0e0dd;
+  border-radius: 10px;
+  background: #ffffff;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+.qr-sidebar-item:hover {
+  border-color: #bbb;
+}
+
+.qr-sidebar-item.active {
+  border-color: #468278;
+  background: #ffffff;
+}
+
+.qr-sidebar-num {
+  flex-shrink: 0;
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #777;
+  width: 1rem;
+  padding-top: 1px;
+}
+
+.qr-sidebar-item.active .qr-sidebar-num {
+  color: #468278;
+}
+
+.qr-sidebar-preview {
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 0.78rem;
+  color: #333;
+  line-height: 1.4;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.qr-sidebar-footer {
+  padding: 0.75rem 0.65rem;
+  border-top: 1px solid #e0e0dd;
+}
+
+.qr-finish-btn {
+  width: 100%;
+  padding: 0.7rem 1rem;
+  background: #111;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.qr-finish-btn:hover {
+  background: #333;
+}
+
+/* ─── Main panel ─── */
+
+.qr-main {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.qr-card {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border: 1px solid #e0e0dd;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+}
+
+/* ─── Card top bar ─── */
+
+.qr-card-topbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1.1rem 1.4rem 0.85rem;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+
+.qr-card-topleft {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.qr-question-label-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.qr-question-label {
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #111;
+}
+
+.qr-points-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.qr-save-error {
+  margin: 0;
+  font-size: 0.78rem;
+  color: #c0392b;
+}
+
+.qr-card-topright {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.qr-card-topright-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.qr-question-type {
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 0.82rem;
+  font-style: italic;
+  color: #666;
+}
+
+.qr-save-text-btn {
+  padding: 0.3rem 0.9rem;
+  background: #111;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.qr-save-text-btn:hover {
+  background: #333;
+}
+
+.qr-save-text-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Question delete trash button — bare, no box */
+.qr-trash-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 100ms ease;
+}
+
+.qr-trash-btn:hover {
+  background: rgba(217, 48, 37, 0.08);
+}
+
+/* ─── Question textarea ─── */
+
+.qr-question-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0 1.4rem;
+  width: calc(100% - 2.8rem);
+  padding: 1rem 1.1rem;
+  border: none;
+  border-radius: 10px;
+  background: #f5f5f3;
+  resize: none;
+  font-family: "Red Hat Display", sans-serif;
+  font-size: clamp(0.95rem, 1.35vw, 1.15rem);
+  font-weight: 400;
+  color: #111;
+  line-height: 1.55;
+  outline: none;
+  flex-shrink: 0;
+}
+
+/* ─── Answer choices ─── */
+
+.qr-choices {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 0.75rem 1.4rem;
+  flex: 1;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #ccc #fff;
+}
+
+.qr-choices::-webkit-scrollbar {
+  width: 5px;
+}
+
+.qr-choices::-webkit-scrollbar-thumb {
+  background: #ccc;
+  border-radius: 999px;
+}
+
+.qr-choice-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Custom radio circle */
+.qr-radio-circle {
+  flex-shrink: 0;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  border: 2px solid #c8c8c4;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.qr-radio-circle.correct {
+  border-color: #468278;
+  background: #468278;
+}
+
+.qr-choice-input {
+  flex: 1;
+  padding: 0.6rem 0.9rem;
+  border: 1.5px solid #e0e0dd;
+  border-radius: 8px;
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 0.95rem;
+  color: #111;
+  background: #fafaf9;
+  outline: none;
+  box-sizing: border-box;
+  cursor: default;
+}
+
+.qr-choice-input.correct {
+  border-color: #468278;
+  background: #f0f8f5;
+}
+
+/* Choice trash button — bare */
+.qr-choice-trash-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 100ms ease;
+}
+
+.qr-choice-trash-btn:hover {
+  background: rgba(217, 48, 37, 0.08);
+}
+
+/* ─── Add question button ─── */
+
+.qr-add-question-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: calc(100% - 2.8rem);
+  margin: 0 1.4rem 1.1rem;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  border: 1.5px dashed #c0c0bc;
+  border-radius: 10px;
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #888;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+.qr-add-question-btn:hover {
+  border-color: #888;
+  color: #444;
+}
+
+/* ─── Navigation (outside card) ─── */
+
+.qr-nav {
+  display: flex;
+  gap: 0.75rem;
+  flex-shrink: 0;
+}
+
+.qr-nav-back,
+.qr-nav-next {
+  flex: 1;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  font-family: "Red Hat Display", sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.qr-nav-back {
+  background: #ffffff;
+  border: 1.5px solid #d0d0cc;
+  color: #111;
+}
+
+.qr-nav-back:hover {
+  border-color: #999;
+}
+
+.qr-nav-next {
+  background: #468278;
+  border: none;
+  color: #ffffff;
+}
+
+.qr-nav-next:hover {
+  background: #3a6e65;
+}
+
+/* ─── Responsive ─── */
+
+@media (max-width: 780px) {
+  .qr-layout {
+    flex-direction: column;
+  }
+
+  .qr-sidebar {
+    width: 100%;
+    max-height: 200px;
+  }
+
+  .qr-sidebar-list {
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .qr-sidebar-item {
+    flex-direction: column;
+    min-width: 100px;
+    flex-shrink: 0;
+  }
+}

--- a/assessly/src/styles/quizStructure.css
+++ b/assessly/src/styles/quizStructure.css
@@ -663,6 +663,92 @@
 }
 
 /* Points input */
+/* Quiz review loading screen */
+.quiz-review-loading-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    gap: 2rem;
+    height: calc(100vh - 60px);
+}
+
+.quiz-review-loading-text {
+    font-family: "Red Hat Display", sans-serif;
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: #171717;
+    margin: 0;
+}
+
+/* Hourglass loader */
+.loader {
+    --c1: #673b14;
+    --c2: #f8b13b;
+    width: 40px;
+    height: 80px;
+    border-top: 4px solid var(--c1);
+    border-bottom: 4px solid var(--c1);
+    background: linear-gradient(90deg, var(--c1) 2px, var(--c2) 0 5px, var(--c1) 0) 50%/7px 8px no-repeat;
+    display: grid;
+    overflow: hidden;
+    animation: l5-0 2s infinite linear;
+}
+
+.loader::before,
+.loader::after {
+    content: "";
+    grid-area: 1/1;
+    width: 75%;
+    height: calc(50% - 4px);
+    margin: 0 auto;
+    border: 2px solid var(--c1);
+    border-top: 0;
+    box-sizing: content-box;
+    border-radius: 0 0 40% 40%;
+    -webkit-mask:
+        linear-gradient(#000 0 0) bottom/4px 2px no-repeat,
+        linear-gradient(#000 0 0);
+    -webkit-mask-composite: destination-out;
+    mask-composite: exclude;
+    background:
+        linear-gradient(var(--d, 0deg), var(--c2) 50%, #0000 0) bottom/100% 205%,
+        linear-gradient(var(--c2) 0 0) center/0 100%;
+    background-repeat: no-repeat;
+    animation: inherit;
+    animation-name: l5-1;
+}
+
+.loader::after {
+    transform-origin: 50% calc(100% + 2px);
+    transform: scaleY(-1);
+    --s: 3px;
+    --d: 180deg;
+}
+
+@keyframes l5-0 {
+    80%  { transform: rotate(0); }
+    100% { transform: rotate(0.5turn); }
+}
+
+@keyframes l5-1 {
+    10%, 70%  { background-size: 100% 205%, var(--s, 0) 100%; }
+    70%, 100% { background-position: top, center; }
+}
+
+.quiz-review-new-changes-badge {
+    display: inline-block;
+    margin-top: 0.25rem;
+    padding: 0.15rem 0.55rem;
+    font-family: "Red Hat Display", sans-serif;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: #ffffff;
+    background: #2d6a5f;
+    border-radius: 999px;
+}
+
 .quiz-review-points-row {
     display: flex;
     align-items: center;

--- a/assessly/src/styles/quizStructure.css
+++ b/assessly/src/styles/quizStructure.css
@@ -684,8 +684,8 @@
 
 /* Hourglass loader */
 .loader {
-    --c1: #673b14;
-    --c2: #f8b13b;
+    --c1: #2d5f56;
+    --c2: #83c7bf;
     width: 40px;
     height: 80px;
     border-top: 4px solid var(--c1);
@@ -1074,6 +1074,52 @@
     outline-offset: 2px;
 }
 
+/* Cube stacking loader */
+.cube-loader {
+  width: 90px;
+  height: 14px;
+  box-shadow: 0 3px 0 #2d5f56;
+  position: relative;
+  clip-path: inset(-40px 0 -5px);
+}
+
+.cube-loader::before {
+  content: "";
+  position: absolute;
+  inset: auto calc(50% - 17px) 0;
+  height: 50px;
+  --g: no-repeat linear-gradient(#468278 0 0);
+  background: var(--g), var(--g), var(--g), var(--g);
+  background-size: 16px 14px;
+  animation:
+    l7-1 2s infinite linear,
+    l7-2 2s infinite linear;
+}
+
+@keyframes l7-1 {
+  0%,
+  100%  { background-position: 0 -50px, 100% -50px; }
+  17.5% { background-position: 0 100%, 100% -50px, 0 -50px, 100% -50px; }
+  35%   { background-position: 0 100%, 100% 100%, 0 -50px, 100% -50px; }
+  52.5% { background-position: 0 100%, 100% 100%, 0 calc(100% - 16px), 100% -50px; }
+  70%,
+  98%   { background-position: 0 100%, 100% 100%, 0 calc(100% - 16px), 100% calc(100% - 16px); }
+}
+
+@keyframes l7-2 {
+  0%, 70% { transform: translate(0); }
+  100%    { transform: translate(200%); }
+}
+
+.quiz-generating-label {
+  font-family: "Red Hat Display", sans-serif;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: 700;
+  font-style: italic;
+  color: #0d1518;
+  margin: 0;
+}
+
 .quiz-generating-overlay {
     position: fixed;
     inset: 0;
@@ -1088,11 +1134,10 @@
 
 .quiz-generating-stack {
     position: relative;
-    width: min(100%, 620px);
     display: flex;
     flex-direction: column;
-    gap: clamp(2rem, 5vh, 3.5rem);
-    filter: drop-shadow(0 12px 18px rgba(123, 167, 159, 0.48));
+    align-items: center;
+    gap: 2rem;
 }
 
 .quiz-generating-row {

--- a/assessly/src/styles/quizStructure.css
+++ b/assessly/src/styles/quizStructure.css
@@ -662,6 +662,92 @@
     gap: 0.7rem;
 }
 
+/* Points input */
+.quiz-review-points-row {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.3rem;
+}
+
+.quiz-review-points-input {
+    width: 3rem;
+    padding: 0.2rem 0.35rem;
+    font-family: "Red Hat Display", sans-serif;
+    font-size: 0.9rem;
+    color: #1f2f2c;
+    background: #f5f5f5;
+    border: 1.5px solid #ccc;
+    border-radius: 6px;
+    outline: none;
+    text-align: center;
+    -moz-appearance: textfield;
+}
+
+.quiz-review-points-input::-webkit-outer-spin-button,
+.quiz-review-points-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.quiz-review-points-input:focus {
+    border-color: #2d6a5f;
+    background: #ffffff;
+}
+
+.quiz-review-points-label {
+    font-family: "Red Hat Display", sans-serif;
+    font-size: 0.85rem;
+    color: #666;
+}
+
+/* Save icon — floppy disk drawn with CSS */
+.quiz-review-save-icon {
+    position: relative;
+    display: block;
+    width: 0.95rem;
+    height: 0.95rem;
+    border: 2.5px solid #ffffff;
+    border-radius: 2px;
+}
+
+.quiz-review-save-icon::before {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: 0.15rem;
+    width: 0.45rem;
+    height: 0.28rem;
+    background: #ffffff;
+    border-radius: 0 0 2px 2px;
+}
+
+.quiz-review-save-icon::after {
+    content: "";
+    position: absolute;
+    bottom: 0.1rem;
+    left: 0.12rem;
+    right: 0.12rem;
+    height: 0.38rem;
+    border: 2px solid #ffffff;
+    border-radius: 1px;
+}
+
+/* Save spinner */
+@keyframes quiz-save-spin {
+    to { transform: rotate(360deg); }
+}
+
+.quiz-review-save-spinner {
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    border: 2.5px solid rgba(255, 255, 255, 0.3);
+    border-top-color: #ffffff;
+    border-radius: 50%;
+    animation: quiz-save-spin 0.7s linear infinite;
+}
+
 .quiz-review-plus-icon {
     font-family: "Red Hat Display", sans-serif;
     font-size: 2.1rem;

--- a/backend/canvas_publisher.py
+++ b/backend/canvas_publisher.py
@@ -239,6 +239,38 @@ def unpublish_canvas_quiz(course_id: int, new_quiz_id: str, canvas_token: str) -
         raise RuntimeError(f"Failed to unpublish quiz: {patch_resp.status_code} {patch_resp.text}")
 
 
+def fetch_canvas_quiz_items(course_id: int, new_quiz_id: str, canvas_token: str) -> list:
+    """
+    Fetches all item (question) data for a New Quiz from Canvas.
+    Returns a list of raw item dicts as returned by Canvas.
+    Raises RuntimeError on failure.
+    """
+    headers = {"Authorization": f"Bearer {canvas_token}"}
+    resp = requests.get(
+        f"{CANVAS_BASE_URL}/api/quiz/v1/courses/{course_id}/quizzes/{new_quiz_id}/items",
+        headers=headers,
+        params={"per_page": 100}
+    )
+    if not resp.ok:
+        raise RuntimeError(f"Failed to fetch quiz items from Canvas: {resp.status_code} {resp.text}")
+    return resp.json()
+
+
+def fetch_canvas_quiz_title(course_id: int, new_quiz_id: str, canvas_token: str) -> str:
+    """
+    Fetches the title of a New Quiz from Canvas.
+    Raises RuntimeError on failure.
+    """
+    headers = {"Authorization": f"Bearer {canvas_token}"}
+    resp = requests.get(
+        f"{CANVAS_BASE_URL}/api/quiz/v1/courses/{course_id}/quizzes/{new_quiz_id}",
+        headers=headers
+    )
+    if not resp.ok:
+        raise RuntimeError(f"Failed to fetch quiz from Canvas: {resp.status_code} {resp.text}")
+    return resp.json().get("title", "")
+
+
 def delete_quiz_from_canvas(course_id: int, new_quiz_id: str, canvas_token: str) -> None:
     """
     Deletes a New Quiz from Canvas. Raises RuntimeError if the request fails.

--- a/backend/canvas_publisher.py
+++ b/backend/canvas_publisher.py
@@ -177,6 +177,34 @@ def publish_existing_canvas_quiz(course_id: int, new_quiz_id: str, canvas_token:
         raise RuntimeError(f"Failed to publish existing quiz: {patch_resp.status_code} {patch_resp.text}")
 
 
+def unpublish_canvas_quiz(course_id: int, new_quiz_id: str, canvas_token: str) -> None:
+    """
+    Unpublishes a quiz on Canvas by PATCHing published=False.
+    The quiz remains on Canvas as an unpublished draft (saved_to_canvas).
+    Raises RuntimeError on failure.
+    """
+    headers = {
+        "Authorization": f"Bearer {canvas_token}",
+        "Content-Type": "application/json"
+    }
+    get_resp = requests.get(
+        f"{CANVAS_BASE_URL}/api/quiz/v1/courses/{course_id}/quizzes/{new_quiz_id}",
+        headers=headers
+    )
+    if not get_resp.ok:
+        raise RuntimeError(f"Failed to fetch quiz for unpublishing: {get_resp.status_code} {get_resp.text}")
+
+    quiz_state = get_resp.json()
+    quiz_state["published"] = False
+    patch_resp = requests.patch(
+        f"{CANVAS_BASE_URL}/api/quiz/v1/courses/{course_id}/quizzes/{new_quiz_id}",
+        headers=headers,
+        json={"quiz": quiz_state}
+    )
+    if not patch_resp.ok:
+        raise RuntimeError(f"Failed to unpublish quiz: {patch_resp.status_code} {patch_resp.text}")
+
+
 def delete_quiz_from_canvas(course_id: int, new_quiz_id: str, canvas_token: str) -> None:
     """
     Deletes a New Quiz from Canvas. Raises RuntimeError if the request fails.

--- a/backend/canvas_publisher.py
+++ b/backend/canvas_publisher.py
@@ -177,6 +177,39 @@ def publish_existing_canvas_quiz(course_id: int, new_quiz_id: str, canvas_token:
         raise RuntimeError(f"Failed to publish existing quiz: {patch_resp.status_code} {patch_resp.text}")
 
 
+def update_item_points_on_canvas(course_id: int, new_quiz_id: str, canvas_item_id: str, points_possible: float, canvas_token: str) -> None:
+    """
+    Updates the points_possible for a single question item already on Canvas.
+    Fetches the full item first then PATCHes it back with the updated points,
+    since the Canvas New Quizzes API requires the full item body on update.
+    Raises RuntimeError on failure.
+    """
+    headers = {
+        "Authorization": f"Bearer {canvas_token}",
+        "Content-Type": "application/json"
+    }
+    get_resp = requests.get(
+        f"{CANVAS_BASE_URL}/api/quiz/v1/courses/{course_id}/quizzes/{new_quiz_id}/items/{canvas_item_id}",
+        headers=headers
+    )
+    if not get_resp.ok:
+        raise RuntimeError(f"Failed to fetch item {canvas_item_id} for points update: {get_resp.status_code} {get_resp.text}")
+
+    item_data = get_resp.json()
+    # points_possible lives at the item level in the Canvas response
+    item_data["points_possible"] = points_possible
+    if "entry" in item_data:
+        item_data["entry"]["points_possible"] = points_possible
+
+    patch_resp = requests.patch(
+        f"{CANVAS_BASE_URL}/api/quiz/v1/courses/{course_id}/quizzes/{new_quiz_id}/items/{canvas_item_id}",
+        headers=headers,
+        json={"item": item_data}
+    )
+    if not patch_resp.ok:
+        raise RuntimeError(f"Failed to update points for item {canvas_item_id}: {patch_resp.status_code} {patch_resp.text}")
+
+
 def unpublish_canvas_quiz(course_id: int, new_quiz_id: str, canvas_token: str) -> None:
     """
     Unpublishes a quiz on Canvas by PATCHing published=False.

--- a/backend/canvas_publisher.py
+++ b/backend/canvas_publisher.py
@@ -74,6 +74,7 @@ def publish_quiz_to_canvas(quiz_doc: dict, canvas_token: str, publish: bool = Tr
         item_payload = {
             "item": {
                 "entry_type": "Item",
+                "points_possible": question.get("points_possible", 1),
                 "entry": {
                     "title": f"Question {question['position']}",
                     "points_possible": question.get("points_possible", 1),

--- a/backend/canvas_publisher.py
+++ b/backend/canvas_publisher.py
@@ -149,6 +149,34 @@ def publish_quiz_to_canvas(quiz_doc: dict, canvas_token: str, publish: bool = Tr
     }
 
 
+def publish_existing_canvas_quiz(course_id: int, new_quiz_id: str, canvas_token: str) -> None:
+    """
+    Publishes a quiz that already exists on Canvas (e.g. was previously saved as a draft).
+    Just PATCHes the existing quiz to set published=True — does NOT create a new quiz shell.
+    Raises RuntimeError on failure.
+    """
+    headers = {
+        "Authorization": f"Bearer {canvas_token}",
+        "Content-Type": "application/json"
+    }
+    get_resp = requests.get(
+        f"{CANVAS_BASE_URL}/api/quiz/v1/courses/{course_id}/quizzes/{new_quiz_id}",
+        headers=headers
+    )
+    if not get_resp.ok:
+        raise RuntimeError(f"Failed to fetch existing quiz for publishing: {get_resp.status_code} {get_resp.text}")
+
+    quiz_state = get_resp.json()
+    quiz_state["published"] = True
+    patch_resp = requests.patch(
+        f"{CANVAS_BASE_URL}/api/quiz/v1/courses/{course_id}/quizzes/{new_quiz_id}",
+        headers=headers,
+        json={"quiz": quiz_state}
+    )
+    if not patch_resp.ok:
+        raise RuntimeError(f"Failed to publish existing quiz: {patch_resp.status_code} {patch_resp.text}")
+
+
 def delete_quiz_from_canvas(course_id: int, new_quiz_id: str, canvas_token: str) -> None:
     """
     Deletes a New Quiz from Canvas. Raises RuntimeError if the request fails.

--- a/backend/canvas_publisher.py
+++ b/backend/canvas_publisher.py
@@ -149,6 +149,19 @@ def publish_quiz_to_canvas(quiz_doc: dict, canvas_token: str, publish: bool = Tr
     }
 
 
+def delete_quiz_from_canvas(course_id: int, new_quiz_id: str, canvas_token: str) -> None:
+    """
+    Deletes a New Quiz from Canvas. Raises RuntimeError if the request fails.
+    """
+    headers = {"Authorization": f"Bearer {canvas_token}"}
+    resp = requests.delete(
+        f"{CANVAS_BASE_URL}/api/quiz/v1/courses/{course_id}/quizzes/{new_quiz_id}",
+        headers=headers
+    )
+    if not resp.ok:
+        raise RuntimeError(f"Failed to delete quiz from Canvas: {resp.status_code} {resp.text}")
+
+
 def get_all_new_quizzes_for_course(course_id: int, canvas_token: str) -> dict:
     """
     Fetches all New Quizzes for a course in one call.

--- a/backend/main.py
+++ b/backend/main.py
@@ -26,7 +26,7 @@ from database import get_or_create_user, update_user, users_collection, course_q
 from clerk_auth import verify_clerk_token
 from canvas_retriever import CanvasContentRetriever
 from gemini_retriever import generate_quiz_from_files
-from canvas_publisher import publish_quiz_to_canvas, publish_existing_canvas_quiz, unpublish_canvas_quiz, update_item_points_on_canvas, get_all_new_quizzes_for_course, delete_quiz_from_canvas
+from canvas_publisher import publish_quiz_to_canvas, publish_existing_canvas_quiz, unpublish_canvas_quiz, update_item_points_on_canvas, fetch_canvas_quiz_items, fetch_canvas_quiz_title, get_all_new_quizzes_for_course, delete_quiz_from_canvas
 import markdown as md_lib
 from encryption import encrypt, decrypt
 
@@ -528,6 +528,182 @@ async def get_quiz(quiz_id: str, current_user: dict = Depends(get_current_user))
 
     quiz_doc["_id"] = str(quiz_doc["_id"])
     return quiz_doc
+
+
+@app.post("/api/quizzes/{quiz_id}/sync-from-canvas")
+async def sync_from_canvas(quiz_id: str, current_user: dict = Depends(get_current_user)):
+    """
+    Pulls the latest quiz data from Canvas and updates MongoDB if anything changed.
+    Compares title, question order, question text, and answer choices.
+    Returns the updated quiz doc and a list of internal_question_ids that had changes.
+    Only applies to quizzes that are saved or published on Canvas.
+    """
+    try:
+        quiz = course_quizzes_collection.find_one({"_id": ObjectId(quiz_id), "clerk_id": current_user["clerk_id"]})
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid quiz ID.")
+    if not quiz:
+        raise HTTPException(status_code=404, detail="Quiz not found.")
+    if quiz.get("status") not in ("saved_to_canvas", "published_on_canvas"):
+        # Not on Canvas — nothing to sync
+        quiz["_id"] = str(quiz["_id"])
+        return {"quiz": quiz, "changed_question_ids": []}
+
+    new_quiz_id = quiz.get("new_quiz_id")
+    course_id = quiz.get("course_id")
+    if not new_quiz_id or not course_id:
+        quiz["_id"] = str(quiz["_id"])
+        return {"quiz": quiz, "changed_question_ids": []}
+
+    canvas_token = current_user.get("canvas_token")
+    if canvas_token:
+        canvas_token = decrypt(canvas_token)
+    if not canvas_token:
+        raise HTTPException(status_code=400, detail="No Canvas token found.")
+
+    try:
+        canvas_title = fetch_canvas_quiz_title(course_id, str(new_quiz_id), canvas_token)
+        canvas_items = fetch_canvas_quiz_items(course_id, str(new_quiz_id), canvas_token)
+    except RuntimeError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+    # Build a lookup of our stored questions by canvas_item_id
+    stored_by_canvas_id = {
+        str(q["canvas_item_id"]): q
+        for q in quiz.get("questions", [])
+        if q.get("canvas_item_id")
+    }
+
+    db_updates = {}
+    changed_question_ids = []
+
+    # Check title
+    if canvas_title and canvas_title != quiz.get("title", ""):
+        db_updates["title"] = canvas_title
+
+    # Sort canvas items by position to determine ordering
+    canvas_items_sorted = sorted(canvas_items, key=lambda x: x.get("position", 0))
+
+    new_questions = list(quiz.get("questions", []))
+
+    for canvas_item in canvas_items_sorted:
+        canvas_item_id = str(canvas_item.get("id", ""))
+        entry = canvas_item.get("entry", {})
+        stored_q = stored_by_canvas_id.get(canvas_item_id)
+
+        if not stored_q:
+            # New question added directly in Canvas — build a new question doc for it
+            canvas_choices = entry.get("interaction_data", {}).get("choices", [])
+            correct_id = entry.get("scoring_data", {}).get("value", "")
+            new_q_id = str(uuid.uuid4())
+            new_q = {
+                "internal_question_id": new_q_id,
+                "canvas_item_id": canvas_item_id,
+                "type": "multiple_choice",
+                "position": canvas_item.get("position", len(new_questions) + 1),
+                "points_possible": canvas_item.get("points_possible", 1),
+                "question_stem_html": entry.get("item_body", ""),
+                "overall_rationale_html": "",
+                "publish_error": None,
+                "choices": [
+                    {
+                        "internal_choice_id": str(c["id"]),
+                        "position": idx + 1,
+                        "text_html": c.get("item_body", ""),
+                        "is_correct": str(c["id"]) == correct_id,
+                    }
+                    for idx, c in enumerate(canvas_choices)
+                ],
+            }
+            new_questions.append(new_q)
+            changed_question_ids.append(new_q_id)
+            continue
+
+        q_idx = next(i for i, q in enumerate(new_questions) if str(q.get("canvas_item_id")) == canvas_item_id)
+        q_changed = False
+        updated_q = dict(new_questions[q_idx])
+
+        # Check position/ordering
+        canvas_position = canvas_item.get("position")
+        if canvas_position and canvas_position != updated_q.get("position"):
+            updated_q["position"] = canvas_position
+            q_changed = True
+
+        # Check points
+        canvas_points = canvas_item.get("points_possible")
+        if canvas_points is not None and canvas_points != updated_q.get("points_possible"):
+            updated_q["points_possible"] = canvas_points
+            q_changed = True
+
+        # Check question stem (item_body lives in entry)
+        canvas_stem = entry.get("item_body", "")
+        if canvas_stem and canvas_stem != updated_q.get("question_stem_html", ""):
+            updated_q["question_stem_html"] = canvas_stem
+            q_changed = True
+
+        # Check answer choices — match by internal_choice_id which we set as the Canvas choice id
+        canvas_choices = entry.get("interaction_data", {}).get("choices", [])
+        if canvas_choices:
+            canvas_choice_by_id = {str(c["id"]): c for c in canvas_choices}
+            correct_id = entry.get("scoring_data", {}).get("value", "")
+            stored_choice_ids = {stored_c["internal_choice_id"] for stored_c in updated_q.get("choices", [])}
+            new_choices = []
+
+            # Update or drop existing stored choices
+            for stored_c in updated_q.get("choices", []):
+                c_id = stored_c["internal_choice_id"]
+                canvas_c = canvas_choice_by_id.get(c_id)
+                if not canvas_c:
+                    # Choice was removed in Canvas — drop it
+                    q_changed = True
+                    continue
+                updated_c = dict(stored_c)
+                if canvas_c.get("item_body", "") != stored_c.get("text_html", ""):
+                    updated_c["text_html"] = canvas_c["item_body"]
+                    q_changed = True
+                updated_c["is_correct"] = (c_id == correct_id)
+                if updated_c["is_correct"] != stored_c["is_correct"]:
+                    q_changed = True
+                new_choices.append(updated_c)
+
+            # Pick up any new choices added directly in Canvas
+            for canvas_c in canvas_choices:
+                c_id = str(canvas_c["id"])
+                if c_id not in stored_choice_ids:
+                    new_choices.append({
+                        "internal_choice_id": c_id,
+                        "position": len(new_choices) + 1,
+                        "text_html": canvas_c.get("item_body", ""),
+                        "is_correct": (c_id == correct_id),
+                    })
+                    q_changed = True
+
+            updated_q["choices"] = new_choices
+
+        if q_changed:
+            new_questions[q_idx] = updated_q
+            changed_question_ids.append(updated_q["internal_question_id"])
+
+    # Remove questions that no longer exist on Canvas
+    canvas_item_ids = {str(item.get("id", "")) for item in canvas_items}
+    new_questions = [q for q in new_questions if not q.get("canvas_item_id") or str(q.get("canvas_item_id")) in canvas_item_ids]
+
+    # Always sync question_count to the true count after additions and deletions
+    if len(new_questions) != quiz.get("question_count"):
+        db_updates["question_count"] = len(new_questions)
+
+    # Re-sort questions by their (possibly updated) position
+    new_questions.sort(key=lambda q: q.get("position", 0))
+
+    if db_updates or changed_question_ids:
+        db_updates["questions"] = new_questions
+        db_updates["updated_at"] = datetime.now(timezone.utc)
+        course_quizzes_collection.update_one({"_id": ObjectId(quiz_id)}, {"$set": db_updates})
+
+    # Return the updated doc
+    updated_doc = course_quizzes_collection.find_one({"_id": ObjectId(quiz_id)})
+    updated_doc["_id"] = str(updated_doc["_id"])
+    return {"quiz": updated_doc, "changed_question_ids": changed_question_ids}
 
 
 @app.post("/api/quizzes/{quiz_id}/save-to-canvas")

--- a/backend/main.py
+++ b/backend/main.py
@@ -26,7 +26,7 @@ from database import get_or_create_user, update_user, users_collection, course_q
 from clerk_auth import verify_clerk_token
 from canvas_retriever import CanvasContentRetriever
 from gemini_retriever import generate_quiz_from_files
-from canvas_publisher import publish_quiz_to_canvas, publish_existing_canvas_quiz, get_all_new_quizzes_for_course, delete_quiz_from_canvas
+from canvas_publisher import publish_quiz_to_canvas, publish_existing_canvas_quiz, unpublish_canvas_quiz, get_all_new_quizzes_for_course, delete_quiz_from_canvas
 import markdown as md_lib
 from encryption import encrypt, decrypt
 
@@ -671,8 +671,8 @@ async def revert_to_draft(quiz_id: str, current_user: dict = Depends(get_current
         raise HTTPException(status_code=400, detail="Invalid quiz ID.")
     if not quiz:
         raise HTTPException(status_code=404, detail="Quiz not found.")
-    if quiz["status"] != "saved_to_canvas":
-        raise HTTPException(status_code=400, detail="Only quizzes saved to Canvas can be reverted to draft.")
+    if quiz["status"] not in ("saved_to_canvas", "published_on_canvas"):
+        raise HTTPException(status_code=400, detail="Only quizzes on Canvas can be reverted to draft.")
 
     new_quiz_id = quiz.get("new_quiz_id")
     course_id = quiz.get("course_id")
@@ -700,3 +700,41 @@ async def revert_to_draft(quiz_id: str, current_user: dict = Depends(get_current
         }}
     )
     return {"reverted": True}
+
+
+@app.post("/api/quizzes/{quiz_id}/unpublish")
+async def unpublish_quiz(quiz_id: str, current_user: dict = Depends(get_current_user)):
+    """
+    Unpublish a quiz on Canvas (sets published=False), keeping it there as a saved draft.
+    Status → saved_to_canvas.
+    """
+    try:
+        quiz = course_quizzes_collection.find_one({"_id": ObjectId(quiz_id), "clerk_id": current_user["clerk_id"]})
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid quiz ID.")
+    if not quiz:
+        raise HTTPException(status_code=404, detail="Quiz not found.")
+    if quiz["status"] != "published_on_canvas":
+        raise HTTPException(status_code=400, detail="Only published quizzes can be unpublished.")
+
+    new_quiz_id = quiz.get("new_quiz_id")
+    course_id = quiz.get("course_id")
+    if not new_quiz_id or not course_id:
+        raise HTTPException(status_code=400, detail="Quiz is missing Canvas IDs.")
+
+    canvas_token = current_user.get("canvas_token")
+    if canvas_token:
+        canvas_token = decrypt(canvas_token)
+    if not canvas_token:
+        raise HTTPException(status_code=400, detail="No Canvas token found.")
+
+    try:
+        unpublish_canvas_quiz(course_id, str(new_quiz_id), canvas_token)
+    except RuntimeError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+    course_quizzes_collection.update_one(
+        {"_id": ObjectId(quiz_id)},
+        {"$set": {"status": "saved_to_canvas", "updated_at": datetime.now(timezone.utc)}}
+    )
+    return {"unpublished": True}

--- a/backend/main.py
+++ b/backend/main.py
@@ -26,7 +26,7 @@ from database import get_or_create_user, update_user, users_collection, course_q
 from clerk_auth import verify_clerk_token
 from canvas_retriever import CanvasContentRetriever
 from gemini_retriever import generate_quiz_from_files
-from canvas_publisher import publish_quiz_to_canvas, get_all_new_quizzes_for_course
+from canvas_publisher import publish_quiz_to_canvas, get_all_new_quizzes_for_course, delete_quiz_from_canvas
 import markdown as md_lib
 from encryption import encrypt, decrypt
 
@@ -612,3 +612,36 @@ async def publish_quiz(quiz_id: str, current_user: dict = Depends(get_current_us
         }}
     )
     return {"quiz_id": quiz_id, "new_quiz_id": publish_result["new_quiz_id"], "assignment_id": publish_result["assignment_id"]}
+
+
+@app.delete("/api/quizzes/{quiz_id}")
+async def delete_quiz(quiz_id: str, current_user: dict = Depends(get_current_user)):
+    """
+    Delete a quiz from MongoDB and, if it exists on Canvas, from Canvas too.
+    """
+    try:
+        quiz = course_quizzes_collection.find_one({"_id": ObjectId(quiz_id), "clerk_id": current_user["clerk_id"]})
+    except Exception:
+        # ObjectId() throws if quiz_id is malformed (wrong format) — that's a bad request, not a missing resource
+        raise HTTPException(status_code=400, detail="Invalid quiz ID.")
+
+    # ObjectId was valid but no document matched — the quiz genuinely doesn't exist
+    if not quiz:
+        raise HTTPException(status_code=404, detail="Quiz not found.")
+
+    # Delete from Canvas if it was published/saved there
+    new_quiz_id = quiz.get("new_quiz_id")
+    course_id = quiz.get("course_id")
+    if new_quiz_id and course_id:
+        canvas_token = current_user.get("canvas_token")
+        if canvas_token:
+            canvas_token = decrypt(canvas_token)
+        if not canvas_token:
+            raise HTTPException(status_code=400, detail="No Canvas token found.")
+        try:
+            delete_quiz_from_canvas(course_id, str(new_quiz_id), canvas_token)
+        except RuntimeError as e:
+            raise HTTPException(status_code=502, detail=str(e))
+
+    course_quizzes_collection.delete_one({"_id": ObjectId(quiz_id)})
+    return {"deleted": True}

--- a/backend/main.py
+++ b/backend/main.py
@@ -657,3 +657,46 @@ async def delete_quiz(quiz_id: str, current_user: dict = Depends(get_current_use
 
     course_quizzes_collection.delete_one({"_id": ObjectId(quiz_id)})
     return {"deleted": True}
+
+
+@app.post("/api/quizzes/{quiz_id}/revert-to-draft")
+async def revert_to_draft(quiz_id: str, current_user: dict = Depends(get_current_user)):
+    """
+    Remove a quiz from Canvas (delete it there) but keep it in MongoDB as a draft.
+    Only valid for quizzes with status saved_to_canvas.
+    """
+    try:
+        quiz = course_quizzes_collection.find_one({"_id": ObjectId(quiz_id), "clerk_id": current_user["clerk_id"]})
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid quiz ID.")
+    if not quiz:
+        raise HTTPException(status_code=404, detail="Quiz not found.")
+    if quiz["status"] != "saved_to_canvas":
+        raise HTTPException(status_code=400, detail="Only quizzes saved to Canvas can be reverted to draft.")
+
+    new_quiz_id = quiz.get("new_quiz_id")
+    course_id = quiz.get("course_id")
+    if new_quiz_id and course_id:
+        canvas_token = current_user.get("canvas_token")
+        if canvas_token:
+            canvas_token = decrypt(canvas_token)
+        if not canvas_token:
+            raise HTTPException(status_code=400, detail="No Canvas token found.")
+        try:
+            delete_quiz_from_canvas(course_id, str(new_quiz_id), canvas_token)
+        except RuntimeError as e:
+            raise HTTPException(status_code=502, detail=str(e))
+
+    # Clear all Canvas IDs and reset status to draft
+    question_clear = {f"questions.{i}.canvas_item_id": None for i in range(len(quiz.get("questions", [])))}
+    course_quizzes_collection.update_one(
+        {"_id": ObjectId(quiz_id)},
+        {"$set": {
+            "status": "generated_pending_review",
+            "new_quiz_id": None,
+            "assignment_id": None,
+            "updated_at": datetime.now(timezone.utc),
+            **question_clear
+        }}
+    )
+    return {"reverted": True}

--- a/backend/main.py
+++ b/backend/main.py
@@ -26,7 +26,7 @@ from database import get_or_create_user, update_user, users_collection, course_q
 from clerk_auth import verify_clerk_token
 from canvas_retriever import CanvasContentRetriever
 from gemini_retriever import generate_quiz_from_files
-from canvas_publisher import publish_quiz_to_canvas, publish_existing_canvas_quiz, unpublish_canvas_quiz, get_all_new_quizzes_for_course, delete_quiz_from_canvas
+from canvas_publisher import publish_quiz_to_canvas, publish_existing_canvas_quiz, unpublish_canvas_quiz, update_item_points_on_canvas, get_all_new_quizzes_for_course, delete_quiz_from_canvas
 import markdown as md_lib
 from encryption import encrypt, decrypt
 
@@ -738,3 +738,59 @@ async def unpublish_quiz(quiz_id: str, current_user: dict = Depends(get_current_
         {"$set": {"status": "saved_to_canvas", "updated_at": datetime.now(timezone.utc)}}
     )
     return {"unpublished": True}
+
+
+class QuestionUpdate(BaseModel):
+    internal_question_id: str
+    points_possible: float
+
+
+class SaveQuizEditsBody(BaseModel):
+    questions: list[QuestionUpdate]
+
+
+@app.patch("/api/quizzes/{quiz_id}/edits")
+async def save_quiz_edits(quiz_id: str, body: SaveQuizEditsBody, current_user: dict = Depends(get_current_user)):
+    """
+    Save edits to quiz questions (currently: points_possible per question).
+    If the quiz is on Canvas, also syncs points to each Canvas item.
+    """
+    try:
+        quiz = course_quizzes_collection.find_one({"_id": ObjectId(quiz_id), "clerk_id": current_user["clerk_id"]})
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid quiz ID.")
+    if not quiz:
+        raise HTTPException(status_code=404, detail="Quiz not found.")
+
+    # Build a lookup from internal_question_id → index in the questions array
+    id_to_index = {q["internal_question_id"]: i for i, q in enumerate(quiz.get("questions", []))}
+
+    updates = {}
+    for q_update in body.questions:
+        idx = id_to_index.get(q_update.internal_question_id)
+        if idx is None:
+            raise HTTPException(status_code=400, detail=f"Question {q_update.internal_question_id} not found in quiz.")
+        updates[f"questions.{idx}.points_possible"] = q_update.points_possible
+
+    updates["updated_at"] = datetime.now(timezone.utc)
+    course_quizzes_collection.update_one({"_id": ObjectId(quiz_id)}, {"$set": updates})
+
+    # If the quiz is already on Canvas, sync points to each item
+    new_quiz_id = quiz.get("new_quiz_id")
+    course_id = quiz.get("course_id")
+    if new_quiz_id and course_id and quiz.get("status") in ("saved_to_canvas", "published_on_canvas"):
+        canvas_token = current_user.get("canvas_token")
+        if canvas_token:
+            canvas_token = decrypt(canvas_token)
+        if canvas_token:
+            questions_by_id = {q["internal_question_id"]: q for q in quiz.get("questions", [])}
+            for q_update in body.questions:
+                q = questions_by_id.get(q_update.internal_question_id)
+                canvas_item_id = q.get("canvas_item_id") if q else None
+                if canvas_item_id:
+                    try:
+                        update_item_points_on_canvas(course_id, str(new_quiz_id), str(canvas_item_id), q_update.points_possible, canvas_token)
+                    except RuntimeError as e:
+                        raise HTTPException(status_code=502, detail=str(e))
+
+    return {"saved": True}

--- a/backend/main.py
+++ b/backend/main.py
@@ -26,7 +26,7 @@ from database import get_or_create_user, update_user, users_collection, course_q
 from clerk_auth import verify_clerk_token
 from canvas_retriever import CanvasContentRetriever
 from gemini_retriever import generate_quiz_from_files
-from canvas_publisher import publish_quiz_to_canvas, get_all_new_quizzes_for_course, delete_quiz_from_canvas
+from canvas_publisher import publish_quiz_to_canvas, publish_existing_canvas_quiz, get_all_new_quizzes_for_course, delete_quiz_from_canvas
 import markdown as md_lib
 from encryption import encrypt, decrypt
 
@@ -588,8 +588,21 @@ async def publish_quiz(quiz_id: str, current_user: dict = Depends(get_current_us
     if quiz_doc["status"] == "published_on_canvas":
         raise HTTPException(status_code=400, detail="Quiz is already published.")
 
+    existing_canvas_id = quiz_doc.get("new_quiz_id")
+
     try:
-        publish_result = publish_quiz_to_canvas(quiz_doc, canvas_token, publish=True)
+        if existing_canvas_id:
+            # Quiz was already saved to Canvas as a draft — just publish it in place, don't recreate it
+            publish_existing_canvas_quiz(quiz_doc["course_id"], str(existing_canvas_id), canvas_token)
+            new_quiz_id = existing_canvas_id
+            assignment_id = quiz_doc.get("assignment_id", existing_canvas_id)
+            question_updates = {}
+        else:
+            # Quiz has never been sent to Canvas — create it and publish in one shot
+            publish_result = publish_quiz_to_canvas(quiz_doc, canvas_token, publish=True)
+            new_quiz_id = publish_result["new_quiz_id"]
+            assignment_id = publish_result["assignment_id"]
+            question_updates = {f"questions.{i}.canvas_item_id": q["canvas_item_id"] for i, q in enumerate(publish_result["questions"])}
     except RuntimeError as e:
         course_quizzes_collection.update_one(
             {"_id": ObjectId(quiz_id)},
@@ -598,20 +611,19 @@ async def publish_quiz(quiz_id: str, current_user: dict = Depends(get_current_us
         raise HTTPException(status_code=502, detail=str(e))
 
     now = datetime.now(timezone.utc)
-    question_updates = {f"questions.{i}.canvas_item_id": q["canvas_item_id"] for i, q in enumerate(publish_result["questions"])}
     course_quizzes_collection.update_one(
         {"_id": ObjectId(quiz_id)},
         {"$set": {
             "status": "published_on_canvas",
-            "new_quiz_id": publish_result["new_quiz_id"],
-            "assignment_id": publish_result["assignment_id"],
+            "new_quiz_id": new_quiz_id,
+            "assignment_id": assignment_id,
             "publish_metadata.published_at": now,
             "publish_metadata.last_error": None,
             "updated_at": now,
             **question_updates
         }}
     )
-    return {"quiz_id": quiz_id, "new_quiz_id": publish_result["new_quiz_id"], "assignment_id": publish_result["assignment_id"]}
+    return {"quiz_id": quiz_id, "new_quiz_id": new_quiz_id, "assignment_id": assignment_id}
 
 
 @app.delete("/api/quizzes/{quiz_id}")


### PR DESCRIPTION
UI Enhancements:

- Updated quiz review screen to look like the figma
- Added hourglass loading animation for clicking a course and quiz on dashboard
- Added factory cubes loading animation while quiz is generating

Backend Enhancements:
- Added functionality to delete a quiz
- Allowing teachers to sync to Canvas w/2 options instead of publishing the quiz immediately by default: (1) Save to Canvas as unpublished (2) Publish the quiz to canvas
- Quiz review modal: if quiz is currently a draft → show delete, save to Canvas, publish to Canvas options
- Quiz review modal: if quiz is already saved to Canvas → show delete, save as draft (deletes it from Canvas only but not the mongo), publish to Canvas options
- Quiz review modal: if quiz is published on Canvas already → show delete, save as draft (deletes it from Canvas only but not the mongo), unpublish from Canvas (changes it to saved status - likely need a new endpoint for this)
- Created an endpoint that reverts a canvas-synced quiz to a draft
- Added functionality for user to change points for each question
- When you click on a quiz, sync the questions and answer choices (if they’re differen, if the questions were re-ordered, new questions added, old questions deleted, etc.)